### PR TITLE
3チーム以上になる場合を考慮するよう変更

### DIFF
--- a/plugins/my_mention.py
+++ b/plugins/my_mention.py
@@ -63,7 +63,7 @@ def end(message):
     splitted_attendee_list = _split_attendee_list(attendee_list, LIMIT_MEMBER_COUNT)
 
     # 各グループごとに名前をランダム生成してslackに通知
-    for i, attendee_group in enumerate(splitted_attendee_list):
+    for attendee_group in splitted_attendee_list:
         team_name = random.sample(KATAKANA, 2)
         message.send('*チーム{}{}パッチョ*'.format(team_name[0], team_name[1]))
         for name in attendee_group:

--- a/plugins/my_mention.py
+++ b/plugins/my_mention.py
@@ -1,3 +1,4 @@
+import math
 import random
 from slackbot.bot import listen_to, respond_to
 
@@ -6,7 +7,12 @@ g_status = {
     'attendee_list': [],
 }
 
-LIMIT_MEMBER_COUNT = 7
+LIMIT_MEMBER_COUNT = 6
+KATAKANA = {chr(n) for n in range(ord(str('ァ')), ord(str('ヾ')))} - {'・', 'ヵ', 'ヶ'}
+KATAKANA -= {'ァ', 'ィ', 'ゥ', 'ェ', 'ォ', 'ッ', 'ャ', 'ュ', 'ョ', 'ヽ', 'ヾ', 'ヮ', 'ー', 'ン'}
+KATAKANA |= {'キャ', 'キュ', 'キョ', 'ギャ', 'ギュ', 'ギョ', 'シャ', 'シュ', 'ショ', 'ジャ', 'ジュ'}
+KATAKANA |= {'ジョ', 'ニャ', 'ニュ', 'ニョ', 'ミャ', 'ミュ', 'ミョ', 'ヒャ', 'ヒュ', 'ヒョ', 'チャ'}
+KATAKANA |= {'チュ', 'チョ', 'リャ', 'リュ', 'リョ', 'ヴァ', 'ヴィ', 'ヴェ', 'ー', 'ン'}
 
 
 @listen_to('.+')
@@ -25,24 +31,41 @@ def start(message):
     g_status['is_open'] = True
 
 
+def _split_attendee_list(attendee_list, limit_member_count):
+    """
+    Parameters
+    ----------
+    attendee_list: list[str]
+        参加希望者の名前のリスト。
+    limit_member_count: int
+        各チームの最大人数を表す自然数。
+
+    Returns
+    ----------
+    各グループに配属された参加者のリストのジェネレータ。
+    """
+    n_teams = math.ceil(len(attendee_list) / limit_member_count)
+    for i_chunk in range(n_teams):
+        yield attendee_list[i_chunk * len(attendee_list) // n_teams:(i_chunk + 1) * len(attendee_list) // n_teams]
+
+
 @respond_to('終了')
 def end(message):
     message.send('募集を終了します <!here>')
     g_status['is_open'] = False
     print(g_status['attendee_list'])
     attendee_list = list(set(g_status['attendee_list']))
-    if len(attendee_list) >= LIMIT_MEMBER_COUNT:
-        random.shuffle(attendee_list)
-        member_count = len(attendee_list) // 2
-        message.send('*チームガスパッチョ*')
-        for name in attendee_list[:member_count]:
-            message.send(name)
-        message.send('*チームデンパッチョ*')
-        for name in attendee_list[member_count:]:
-            message.send(name)
 
-    else:
-        message.send('*チームガスパッチョ*')
-        for name in attendee_list:
+    # attendee_list をランダムに並び替え
+    random.shuffle(attendee_list)
+
+    # メンバー数上限に応じてチームを分割
+    splitted_attendee_list = _split_attendee_list(attendee_list, LIMIT_MEMBER_COUNT)
+
+    # 各グループごとに名前をランダム生成してslackに通知
+    for i, attendee_group in enumerate(splitted_attendee_list):
+        team_name = random.sample(KATAKANA, 2)
+        message.send('*チーム{}{}パッチョ*'.format(team_name[0], team_name[1]))
+        for name in attendee_group:
             message.send(name)
     g_status['attendee_list'] = []

--- a/run.py
+++ b/run.py
@@ -1,11 +1,11 @@
-# -*- coding: utf-8 -*-
 from slackbot.bot import Bot
+
 
 def main():
     bot = Bot()
     bot.run()
 
+
 if __name__ == "__main__":
     print('start slackbot')
     main()
-    


### PR DESCRIPTION
## 概要
本 Pull Request に紐付く commit で、正しくは3チーム以上にチーム分けがなされるべき人数が参加を表明した場合に正しくチーム分けされるように変更しました。

## 詳細
- 従来の実装では、チーム数は2であることがコード中で暗示的に定められており、例えば100人が参加を表明した場合には50人のグループが2つできるといったように、期待されている動作とは異なる挙動が発生する場合がありました。
- チーム数は、各チームの人数上限と参加者数が決定したのちに自動的に決定されることが望ましいといえます。本PRによってこの問題が解決されます。
- また、チーム数が多くなる場合、本botの最重要チャームポイントであるチーム名が枯渇するという問題も同時に発生します。これを解決するため、概ね2文字として発音されるカタカナの組み合わせをランダムに生成し、チーム名を決定します。
- チーム名の総数は 109^2 = 11,881 個あり、現実的な会社の規模で発生するチーム数では多くの場合チーム名の衝突は発生しないことが想定されます。万が一チーム数が非常に大きくなった場合でも、名前空間を拡張することによって衝突を回避するよう変更することは容易です。
- ついでに `run.py` も直しました。

## 関連ページ
https://github.com/mikupaccho/gutto-paccho/issues/3