### PR TITLE
デバッグモードの追加と参加表明の改善

### DIFF
--- a/plugins/my_mention.py
+++ b/plugins/my_mention.py
@@ -15,6 +15,9 @@ KATAKANA |= {'キャ', 'キュ', 'キョ', 'ギャ', 'ギュ', 'ギョ', 'シャ
 KATAKANA |= {'ジョ', 'ニャ', 'ニュ', 'ニョ', 'ミャ', 'ミュ', 'ミョ', 'ヒャ', 'ヒュ', 'ヒョ', 'チャ'}
 KATAKANA |= {'チュ', 'チョ', 'リャ', 'リュ', 'リョ', 'ヴァ', 'ヴィ', 'ヴェ', 'ー', 'ン'}
 
+# YESと判断されるメッセージリスト
+YES_MESSAGE_LIST = ['はい', '行きます', 'おなかすいた']
+
 
 @listen_to('.+')
 def listen(message):
@@ -22,13 +25,13 @@ def listen(message):
     message_text = message.body['text']
     if g_status['is_open']:
         print(send_user, message_text)
-        if message_text in ['はい', '行きます', 'おなかすいた']:
+        if message_text in YES_MESSAGE_LIST:
             g_status['attendee_list'].append('<@{}>'.format(send_user))
 
 
 @respond_to('(.+)?募集')
 def start(message, how_to):
-    start_message = 'はらぺこ軍団全員集合〜「はい」って応答するパッチョ'
+    start_message = 'はらぺこ軍団全員集合〜「{}」って応答するパッチョ'.format(' か、'.join(YES_MESSAGE_LIST))
     if how_to and '静か' in how_to:
         start_message += '(こっそり)'
         g_status['is_silent'] = True

--- a/plugins/my_mention.py
+++ b/plugins/my_mention.py
@@ -57,7 +57,7 @@ def _split_attendee_list(attendee_list, limit_member_count):
     各グループに配属された参加者のリストのジェネレータ。
     """
     n_teams = math.ceil(len(attendee_list) / limit_member_count)
-    for i_chunk in range(n_teams):
+    for i_chunk in range(int(n_teams)):
         yield attendee_list[i_chunk * len(attendee_list) // n_teams:(i_chunk + 1) * len(attendee_list) // n_teams]
 
 

--- a/plugins/my_mention.py
+++ b/plugins/my_mention.py
@@ -27,6 +27,7 @@ def listen(message):
         print(send_user, message_text)
         if message_text in YES_MESSAGE_LIST:
             g_status['attendee_list'].append('<@{}>'.format(send_user))
+            message.react('+1')
 
 
 @respond_to('(.+)?募集')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+certifi==2018.1.18
+chardet==3.0.4
+idna==2.6
+requests==2.18.4
+six==1.11.0
+slackbot==0.5.1
+slacker==0.9.60
+urllib3==1.22
+websocket-client==0.47.0


### PR DESCRIPTION
以下の3点を実装しました。

### デバッグモードの追加

テスト時等に@hereをつけずに実行できるモードを追加しました。`@botname 静かに募集`とするとメンションが省略されます。

### 参加表明のメッセージをわかりやすく変更

はい、以外のメッセージも許容していましたがそれがアナウンスされていなかったので追加しました。

### 参加表明へのメンション

Botが受け取った参加表明にメンションをつけるようにしました。


![franz](https://user-images.githubusercontent.com/4572217/37079632-98b8b1de-2226-11e8-98e6-7b177a2302c2.png)