### PR TITLE
Botが発話してもエラーを返さないように変更

### DIFF
--- a/plugins/my_mention.py
+++ b/plugins/my_mention.py
@@ -21,13 +21,17 @@ YES_MESSAGE_LIST = ['はい', '行きます', 'おなかすいた']
 
 @listen_to('.+')
 def listen(message):
-    send_user = message.channel._client.users[message.body['user']]['name']
-    message_text = message.body['text']
-    if g_status['is_open']:
-        print(send_user, message_text)
-        if message_text in YES_MESSAGE_LIST:
-            g_status['attendee_list'].append('<@{}>'.format(send_user))
-            message.react('+1')
+    user = message.body.get('user')
+    if user:
+        send_user = message.channel._client.users[user]['name']
+        message_text = message.body['text']
+        if g_status['is_open']:
+            print(send_user, message_text)
+            if message_text in YES_MESSAGE_LIST:
+                g_status['attendee_list'].append('<@{}>'.format(send_user))
+                message.react('+1')
+    else:
+        message.send('誰？')
 
 
 @respond_to('(.+)?募集')


### PR DESCRIPTION
## Issue
botなどの `'user'` が存在しないアカウントが発話するとエラーが起こる #22

## 詳細
- Botが発話すると `message.body['user']` が存在しないせいでエラーが返っていました
- なので、これの存在チェックをして適切に反応するようにしました

## 備考
- Botが発話した場合どうなるのかの動作確認が面倒だったので勘で直しました
- とりあえず一般人が発話した場合は今まで通り正常に動くことは確認しています
