### PR TITLE
弁当チームが空のときにチーム名だけ言う問題の解消

### DIFF
--- a/plugins/my_mention.py
+++ b/plugins/my_mention.py
@@ -123,10 +123,11 @@ def end(message):
 
     # 弁当組
     bento_attendee_list = list(set(g_status['bento_attendee_list']))
-    team_name = random.sample(KATAKANA, 1)
-    message.send('*チーム弁{}パッチョ*'.format(team_name[0]))
-    for name in bento_attendee_list:
-        message.send(name)
+    if bento_attendee_list:
+        team_name = random.sample(KATAKANA, 1)
+        message.send('*チーム弁{}パッチョ*'.format(team_name[0]))
+        for name in bento_attendee_list:
+            message.send(name)
 
     # 募集状態のリセット
     _reset_state()


### PR DESCRIPTION
弁当チームが空のときにチーム名だけ言う問題を解消しました。

### Before
<img width="654" alt="2018-08-12 15 17 55" src="https://user-images.githubusercontent.com/7949819/43999213-02188d3c-9e43-11e8-9735-214ae887acf6.png">

### After
<img width="657" alt="2018-08-12 15 18 03" src="https://user-images.githubusercontent.com/7949819/43999214-023a1308-9e43-11e8-8d37-72ad88aa5d37.png">
